### PR TITLE
fix: multiple modules connecting to BMS

### DIFF
--- a/Core/Src/TEMInterface.c
+++ b/Core/Src/TEMInterface.c
@@ -17,8 +17,6 @@ void startTEMInterfaceTask() {
     uint8_t current_thermistor_id = 0;
 
 
-    //	ERROR_PRINT("STARTING UP TEM INTERFACE TASK");
-
     while (1) {
         // GRCprintf("Sending out to queue");
         // Grab the current module ID.
@@ -50,12 +48,10 @@ void startTEMInterfaceTask() {
     	bms_broadcast.data[2] = *(uint8_t*)(&maximum_thermistor_temperature);
     	bms_broadcast.data[3] = *(uint8_t*)(&average_thermistor_temperature);
     	bms_broadcast.data[4] = THERMISTOR_COUNT;
+    	bms_broadcast.data[5] = THERMISTOR_COUNT - 1;
+    	bms_broadcast.data[6] = 0;
 
-    	// The TEM Modules seem to get the min ID and max ID backwards compared to the spec, so we just copy them again here.
-    	bms_broadcast.data[5] = 0;
-    	bms_broadcast.data[6] = THERMISTOR_COUNT - 1;
-
-    	uint8_t bms_broadcast_checksum = module_number + 1 + 0x40; // Module number + 1, plus length (8) shifted to the left 4 bits
+    	uint8_t bms_broadcast_checksum = 0x39 + 0x8; // Module number + 1, plus length (8) shifted to the left 4 bits
     	for (uint8_t i = 0; i < 7; i++) {
     		bms_broadcast_checksum += bms_broadcast.data[i];
     	}
@@ -63,21 +59,19 @@ void startTEMInterfaceTask() {
 
     	// The TEM modules don't actually seem to offset their module numbers even though the CAN specification says they should.
     	general_broadcast.header.ExtId = 0x1838F380 + module_number; // The CAN ID is offset by the module number
-    	uint16_t relative_thermistor_id = (uint16_t)module_number * 80 + current_thermistor_id;
-    	general_broadcast.data[0] = (uint8_t)((relative_thermistor_id & 0xFF00) >> 8);
-    	general_broadcast.data[1] = (uint8_t)(relative_thermistor_id & 0x00FF);
+    	uint16_t absolute_thermistor_id = (uint16_t)module_number * 80 + current_thermistor_id;
+    	general_broadcast.data[0] = (uint8_t)((absolute_thermistor_id & 0xFF00) >> 8);
+    	general_broadcast.data[1] = (uint8_t)(absolute_thermistor_id & 0x00FF);
     	general_broadcast.data[2] = *(uint8_t*)(&ThermistorData.thermistors[current_thermistor_id]);
 
-    	// The TEM modules don't seem to broadcast the thermistor count, instead they just repeat the thermistor value.
-    	general_broadcast.data[3] = *(uint8_t*)(&ThermistorData.thermistors[current_thermistor_id]);
-		// general_broadcast.data[3] = THERMISTOR_COUNT;
+    	// The TEM modules don't seem to broadcast the thermistor count, instead they just repeat the module relative thermistor ID.
+    	general_broadcast.data[3] = current_thermistor_id;
 
     	general_broadcast.data[4] = *(uint8_t*)(&minimum_thermistor_temperature); // Min thermistor
     	general_broadcast.data[5] = *(uint8_t*)(&maximum_thermistor_temperature); // Max thermistor
+    	general_broadcast.data[6] = THERMISTOR_COUNT - 1;
+    	general_broadcast.data[7] = 0;
 
-    	// The TEM Modules seem to get the min ID and max ID backwards compared to the spec, so we just copy them again here.
-    	general_broadcast.data[6] = 0;
-    	general_broadcast.data[7] = THERMISTOR_COUNT - 1;
 
 
         osMessageQueuePut(CANTX_QHandle, &bms_broadcast, 0, 0);


### PR DESCRIPTION
# MULTIPLE SEGMENT BMS COMPATIBILITY

Fixed implementation of multiple segment board compatibility with the BMS over CAN. Minor adjustments to the CAN format was done as well to match the Orion BMS CAN specification.

## Changes

- Reversed order of highest and lowest thermistor ID bytes in the CAN specification
- Changed the checksum formula to remove the redundant module number as it is already included in the first byte

## Deployment

- N/A

## Proof of functionality (screenshot, logs, etc)

![image](https://github.com/GryphonRacingFSAE/SMU-Firmware/assets/56515924/918829ec-b91a-47c3-97dd-9ee96d6666cf)
Three boards working simultaneously 

## Checklist

- [x] Your code builds clean without any errors or warnings
- [ ] Code has been formatted (clang-format, cmake-format, black, prettier, rustfmt, etc)
- [x] Where possible, unit tests have been added
- [x] Code is well-commented & understood
